### PR TITLE
Fix issue #4. Make scenario display name JUnit-safe.

### DIFF
--- a/src/main/java/org/jbehave/scenario/finegrained/junit/monitoring/JUnitDescriptionGenerator.java
+++ b/src/main/java/org/jbehave/scenario/finegrained/junit/monitoring/JUnitDescriptionGenerator.java
@@ -26,7 +26,7 @@ public class JUnitDescriptionGenerator {
 	}
 
 	public Description createDescriptionFrom(Scenario scenario) {
-        Description scenarioDescription = Description.createSuiteDescription("Scenario: " + scenario.getTitle());
+        Description scenarioDescription = Description.createSuiteDescription("Scenario: " + getJunitSafeString(scenario.getTitle()));
         if (hasGivenStories(scenario)) {
         	insertGivenStories(scenario, scenarioDescription);
         }
@@ -98,7 +98,7 @@ public class JUnitDescriptionGenerator {
     }
 
     public String getJunitSafeString(String string) {
-        return uniq.getUniqueDescription(string.replaceAll("\n", ", ").replaceAll("[\\(\\)]", "|"));
+        return uniq.getUniqueDescription(string.replaceAll("\r", "\n").replaceAll("\n{2,}", "\n").replaceAll("\n", ", ").replaceAll("[\\(\\)]", "|"));
     }
 
 	public int getTestCases() {

--- a/src/test/java/org/jbehave/scenario/finegrained/junit/monitoring/JUnitDescriptionGeneratorTest.java
+++ b/src/test/java/org/jbehave/scenario/finegrained/junit/monitoring/JUnitDescriptionGeneratorTest.java
@@ -1,5 +1,6 @@
 package org.jbehave.scenario.finegrained.junit.monitoring;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
@@ -116,6 +117,30 @@ public class JUnitDescriptionGeneratorTest {
 		Description description = generator.createDescriptionFrom(story);
 		assertThat(description.getChildren(), hasItem(Description.createSuiteDescription("Scenario: " + DEFAULT_SCENARIO_TITLE)));
 	}
+	
+	@Test
+	public void shouldStripLinebreaksFromScenarioDescriptions() {
+		Scenario scenario = mock(Scenario.class);
+		when(story.getScenarios()).thenReturn(Arrays.asList(new Scenario[] {scenario}));
+		when(scenario.getGivenStories()).thenReturn(givenStories);
+
+		when(scenario.getTitle()).thenReturn("Scenario with\nNewline");
+		Description description = generator.createDescriptionFrom(story);
+		assertThat(description.getChildren().get(0).getDisplayName(), not(containsString("\n")));
+	}
+	
+	@Test
+	public void shouldStripCarriageReturnsFromScenarioDescriptions() {
+		Scenario scenario = mock(Scenario.class);
+		when(story.getScenarios()).thenReturn(Arrays.asList(new Scenario[] {scenario}));
+		when(scenario.getGivenStories()).thenReturn(givenStories);
+
+		when(scenario.getTitle()).thenReturn("Scenario with\rCarriage Return");
+		Description description = generator.createDescriptionFrom(story);
+		assertThat(description.getChildren().get(0).getDisplayName(), not(containsString("\r")));
+	}
+	
+	
 
 	@Test
 	public void shouldCopeWithSeeminglyDuplicateSteps() throws Exception {


### PR DESCRIPTION
When a scenario description spanned multiple lines, it would not
display correctly in Eclipse's JUnit view. The patch adds "\r" as
a character that needs to be removed/replaced and makes sure the
scenario display name is escaped properly.
